### PR TITLE
add pixelated image-rendering CSS to the map

### DIFF
--- a/client/world.css
+++ b/client/world.css
@@ -48,6 +48,10 @@ body {
     color: white;
 }
 
+#map {
+    image-rendering: pixelated;
+}
+
 .chatarea {
     background-color: #333;
     color: white;


### PR DESCRIPTION
Adds CSS to the map canvas to make it use nearest-neighbor pixel scaling instead of becoming blurry when the 2x zoom option is on.