### PR TITLE
add typing notifications

### DIFF
--- a/client/js/online.js
+++ b/client/js/online.js
@@ -193,6 +193,13 @@ function receiveServerMessage(event) {
         delete PlayerWho[arg.remove];
 
         NeedMapRedraw = true;
+      } else if(arg.update) {
+        PlayerWho[arg.update.id] = Object.assign(
+          PlayerWho[arg.update.id],
+          arg.update
+        );
+
+        NeedMapRedraw = true;
       }
 
       // has anyone's avatars updated?

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -103,10 +103,19 @@ function logMessage(Message, Class) {
 function setChatInput(the_text) {
   chatInput.value = the_text;
   chatInput.focus();
+  sendTyping(true);
 }
 
 function sendChatCommand(the_text) {
   SendCmd("CMD", {text: the_text});
+}
+
+function sendTyping(isTyping) {
+  if(PlayerWho[PlayerYou].typing != isTyping){
+    SendCmd("WHO", {update: {id: PlayerYou, typing: isTyping}});
+    PlayerWho[PlayerYou].typing = isTyping;
+    drawMap();
+  }
 }
 
 function PlayersAroundTile(FindX, FindY, Radius) {
@@ -312,6 +321,9 @@ function keyHandler(e) {
       } else {
         chatInput.blur();
       }
+
+      sendTyping(false);
+
       chatInput.value = "";
     } else if(document.activeElement == chatInput && e.keyCode == 27) {
       // escape press
@@ -504,6 +516,13 @@ function drawMap() {
     } else {
       ctx.drawImage(IconSheets[Mob.pic[0]], Mob.pic[1]*16, Mob.pic[2]*16, 16, 16, (Mob.x*16)-PixelCameraX, (Mob.y*16)-PixelCameraY, 16, 16);
     }
+
+    // typing indicators
+    if(Mob.typing) {
+      ctx.drawImage(IconSheets[0], 0, 24*16, 16, 16, (Mob.x*16)-PixelCameraX, ((Mob.y-1)*16)-PixelCameraY, 16, 16);
+    }
+
+    // carry text and nametags
     if(IsMousedOver && !(!Mob.is_following && Mob.vehicle)) {
       if(Mob.passengers.length > 0) {
         drawText(ctx, (Mob.x*16)-PixelCameraX-(Mob.name.length * 8 / 2 - 8), (Mob.y*16)-PixelCameraY-24, Mob.name);
@@ -910,6 +929,16 @@ function initWorld() {
 
   chatInput = document.getElementById("chatInput");
   mapCanvas = document.getElementById("map");
+
+  chatInput.addEventListener('input', function (evt) {
+    if(this.value.length > 0){
+      sendTyping(true);
+    }
+  });
+
+  chatInput.addEventListener('blur', function (evt) {
+    sendTyping(false);
+  });
 
   viewInit();
 

--- a/pyserver/tilemaptown_server/buildprotocol.py
+++ b/pyserver/tilemaptown_server/buildprotocol.py
@@ -41,6 +41,17 @@ def tileIsOkay(tile):
 
 	return (True, None)
 
+CLIENT_WHO_WHITELIST = {
+	"typing": bool
+}
+
+def validate_client_who(id, data):
+	validated_data = {"id": id}
+	for key, value in data.items():
+		if key in CLIENT_WHO_WHITELIST:
+			validated_data[key] = CLIENT_WHO_WHITELIST[key](value)
+	return validated_data
+
 # -------------------------------------
 
 def fn_MOV(self, client, arg):
@@ -293,6 +304,16 @@ def fn_BLK(self, client, arg):
 	else:
 		client.send("ERR", {'text': 'Bulk building is disabled on this map'})
 handlers['BLK'] = fn_BLK
+
+def fn_WHO(self, client, arg):
+	if arg["update"]:
+		valid_data = validate_client_who(client.id, arg["update"])
+		for key,value in valid_data.items():
+			setattr(client,key,value)
+		client.map.broadcast("WHO", {"update": valid_data})
+	else:
+		client.send("ERR", {'text': 'not implemented'})
+handlers['WHO'] = fn_WHO
 
 # -------------------------------------
 

--- a/pyserver/tilemaptown_server/server.py
+++ b/pyserver/tilemaptown_server/server.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio, datetime, random, websockets, json, sys
+import asyncio, datetime, random, websockets, json, sys, traceback
 from .buildglobal import *
 from .buildmap import *
 from .buildclient import *
@@ -136,6 +136,8 @@ async def clientHandler(websocket, path):
 		print("disconnected: %s (%s, \"%s\")" % (client.ip, client.username or "?", client.name))
 	except:
 		print("Unexpected error:", sys.exc_info()[0])
+		print(sys.exc_info()[1])
+		traceback.print_tb(sys.exc_info()[2])
 #		raise
 
 	client.cleanup()


### PR DESCRIPTION
Adds typing indicators using the "..." graphic from the potluck tileset. Uses a new subcommand of `WHO` called `"update"` to update just the `typing` variable to avoid having to rebroadcast the entire player object. Also adds tracebacks to errors in the python server to help with debugging.