### PR TITLE
zoom without scroll wheel

### DIFF
--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -69,6 +69,9 @@ var BumpCooldown = 0;
 const FolderOpenPic = [0, 2, 20];
 const FolderClosedPic = [0, 1, 20];
 
+const CameraScaleMin = 1;
+const CameraScaleMax = 8;
+
 function getRandomInt(min, max) {
   min = Math.ceil(min);
   max = Math.floor(max);
@@ -1095,6 +1098,37 @@ function getTilePos(evt) {
   return pos;
 }
 
+function zoomIn() {
+  CameraScale = Math.min(Math.max(CameraScaleMin, CameraScale + 0.25), CameraScaleMax);
+  resizeCanvas();
+  updateZoomLevelDisplay();
+}
+
+function zoomOut() {
+  CameraScale = Math.min(Math.max(CameraScaleMin, CameraScale - 0.25), CameraScaleMax);
+  resizeCanvas();
+  updateZoomLevelDisplay();
+}
+
+function updateZoomLevelDisplay() {
+  let readout = document.querySelector('#zoomlevel');
+  let inButt  = document.querySelector('#zoomin');
+  let outButt = document.querySelector('#zoomout');
+
+  readout.innerText = `${CameraScale.toFixed(2)}x`
+
+  if (CameraScale <= CameraScaleMin) {
+    outButt.disabled = true;
+    inButt.disabled = false;
+  } else if (CameraScale >= CameraScaleMax) {
+    outButt.disabled = false;
+    inButt.disabled = true;
+  } else {
+    outButt.disabled = false;
+    inButt.disabled = false;
+  }
+}
+
 function initMouse() {
   var edittilesheetselect = document.getElementById("edittilesheetselect");
 
@@ -1152,8 +1186,9 @@ function initMouse() {
     CameraScale += event.deltaY * -0.01;
 
     // Restrict CameraScale
-    CameraScale = Math.min(Math.max(1, CameraScale), 8);
+    CameraScale = Math.min(Math.max(CameraScaleMin, CameraScale), CameraScaleMax);
 
+    updateZoomLevelDisplay();
     resizeCanvas();
   }, false);
 

--- a/client/world.css
+++ b/client/world.css
@@ -277,3 +277,8 @@ widget-contextmenu li:hover {
     font-size: 0.8em;
     font-style: italic;
 }
+
+#options ul {
+    padding-left: 1.5em;
+    margin: 0.5em 0;
+}

--- a/client/world.css
+++ b/client/world.css
@@ -172,6 +172,7 @@ body {
 
 #chatInput {
     pointer-events: initial;
+    box-sizing: border-box;
 }
 
 #chat-container .chatarea * {

--- a/client/world.html
+++ b/client/world.html
@@ -242,6 +242,16 @@
     <input type="checkbox" id="audionotify"><label for="audionotify" class="unselectable">Notify when people talk</label></input><br>
     <input type="checkbox" id="option-fly"><label for="option-fly" class="unselectable">Walk through walls</label></input><br>
 
+    <ul>
+      <li>
+        Zoom level:
+
+        <input id="zoomout" type="button" onclick="zoomOut();" value="-">
+        <span id="zoomlevel">1.00x</span>
+        <input id="zoomin" type="button" onclick="zoomIn();" value="+">
+      </li>
+    </ul>
+
     <input type="button" onclick="applyOptions(); viewOptions();" value="OK">
     <input type="button" onclick="applyOptions();" value="Apply changes">
     <input type="button" onclick="viewOptions();" value="Close options">


### PR DESCRIPTION
Adds a zoom level display and buttons to zoom in and out to the options menu. And fixes a bug that was making my window scroll horizontally when the chat log was pinned!