### PR TITLE
clear loaded_maps when entering map with no connections

### DIFF
--- a/pyserver/tilemaptown_server/buildentity.py
+++ b/pyserver/tilemaptown_server/buildentity.py
@@ -267,6 +267,9 @@ class Entity(object):
 			'turf': [],
 			'obj': []
 		})
+
+		item.loaded_maps = set([self.db_id])
+
 		self.broadcast("MOV", {'id': item.protocol_id(), 'to': [random.randint(0, 9), random.randint(0, 9)]})
 
 	# Permission checking


### PR DESCRIPTION
clears loaded_maps when sending the map info for an inventory map so that you receive the map info for the map you left if you go back there