### PR TITLE
Remove focus from radio buttons after picking build tool

### DIFF
--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -2777,6 +2777,8 @@ function changeBuildTool() {
         MouseActive = false;
         NeedMapRedraw = true;
     }
+  // Remove focus from the radio buttons, restoring the player's ability to move around
+  document.activeElement.blur();
 }
 
 function copyTurfFromSelection() {


### PR DESCRIPTION
This is a tiny QOL improvement I did to start exploring the code.